### PR TITLE
Fix package dependencies and update rviz config

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ sudo apt install ros-$ROS_DISTRO-ackermann-steering-controller ros-$ROS_DISTRO-c
 catkin_make
 ```
 
+Alternatively, install all the system dependencies using rosdep:
+```
+cd <your_workspace>
+rosdep install --from-paths src --ignore-src -r -y
+```
+
 ## Launch
 One droid in Gazebo
 ```

--- a/mse6_config/config/rviz/one_droid.rviz
+++ b/mse6_config/config/rviz/one_droid.rviz
@@ -6,7 +6,7 @@ Panels:
       Expanded:
         - /TF1/Tree1
       Splitter Ratio: 0.5
-    Tree Height: 259
+    Tree Height: 243
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -95,6 +95,22 @@ Visualization Manager:
           Value: true
         mse6_00000/odom:
           Value: true
+        mse6_00000/sonar_bl_link:
+          Value: true
+        mse6_00000/sonar_br_link:
+          Value: true
+        mse6_00000/sonar_fl_link:
+          Value: true
+        mse6_00000/sonar_fr_link:
+          Value: true
+        mse6_00000/sonar_lb_link:
+          Value: true
+        mse6_00000/sonar_lf_link:
+          Value: true
+        mse6_00000/sonar_rb_link:
+          Value: true
+        mse6_00000/sonar_rf_link:
+          Value: true
       Marker Alpha: 1
       Marker Scale: 0.5
       Name: TF
@@ -127,6 +143,22 @@ Visualization Manager:
                 mse6_00000/holocamera_optical_link:
                   {}
               mse6_00000/laser_scanner_link:
+                {}
+              mse6_00000/sonar_bl_link:
+                {}
+              mse6_00000/sonar_br_link:
+                {}
+              mse6_00000/sonar_fl_link:
+                {}
+              mse6_00000/sonar_fr_link:
+                {}
+              mse6_00000/sonar_lb_link:
+                {}
+              mse6_00000/sonar_lf_link:
+                {}
+              mse6_00000/sonar_rb_link:
+                {}
+              mse6_00000/sonar_rf_link:
                 {}
       Update Interval: 0
       Value: true
@@ -214,6 +246,38 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
+        mse6_00000/sonar_bl_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_br_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_fl_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_fr_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_lb_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_lf_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_rb_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        mse6_00000/sonar_rf_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
       Name: MSE6_00000
       Robot Description: /mse6_00000/robot_description
       TF Prefix: ""
@@ -230,7 +294,7 @@ Visualization Manager:
       Length: 0.30000001192092896
       Line Style: Lines
       Line Width: 0.029999999329447746
-      Name: GloabalPlan
+      Name: GlobalPlan
       Offset:
         X: 0
         Y: 0
@@ -371,6 +435,86 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar BackLeft
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_bl_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar BackRight
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_br_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar ForwardLeft
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_fl_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar ForwardRight
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_fr_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar LeftBack
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_lb_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar LeftForward
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_lf_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar RightBack
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_rb_link
+      Unreliable: false
+      Value: true
+    - Alpha: 0.5
+      Buffer Length: 1
+      Class: rviz/Range
+      Color: 255; 255; 255
+      Enabled: true
+      Name: Sonar RightForward
+      Queue Size: 10
+      Topic: /mse6_00000/sensors/rangefinders/sonar_rf_link
+      Unreliable: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -422,12 +566,12 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1051
+  Height: 1009
   Hide Left Dock: false
   Hide Right Dock: false
   HolocameraImage:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000361fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007901000003fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000004400000150000000fd01000003fb0000001e0048006f006c006f00630061006d0065007200610049006d0061006700650100000195000000ec0000002201000003fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00540065006c0065006f00700100000282000001230000005401000003000000010000011000000361fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000004400000361000000d301000003fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000004efc0100000002fb0000000800540069006d0065010000000000000780000002ad01000003fb0000000800540069006d00650100000000000004500000000000000000000005040000036100000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000337fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007901000003fb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000004400000140000000fd01000003fb0000001e0048006f006c006f00630061006d0065007200610049006d0061006700650100000185000000e00000002201000003fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00540065006c0065006f00700100000266000001150000005401000003000000010000011000000337fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000004400000337000000d301000003fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000004efc0100000002fb0000000800540069006d0065010000000000000780000002ad01000003fb0000000800540069006d00650100000000000004500000000000000000000005040000033700000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Teleop:

--- a/mse6_config/package.xml
+++ b/mse6_config/package.xml
@@ -49,6 +49,15 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>ackermann_steering_controller</depend>
+  <depend>costmap_2d</depend>
+  <depend>nav_core</depend>
+  <depend>base_local_planner</depend>
+  <depend>teb_local_planner</depend>
+  <depend>map_server</depend>
+  <depend>move_base</depend>
+  <depend>global_planner</depend>
+  <depend>hector_gazebo_plugins</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/mse6_description/package.xml
+++ b/mse6_description/package.xml
@@ -17,7 +17,7 @@ for mse6_description robot</p>
   <depend>rviz</depend>
   <depend>joint_state_publisher_gui</depend>
   <depend>gazebo</depend>
-  <depend>ros-noetic-hector-gazebo-plugins</depend>
+  <depend>hector_gazebo_plugins</depend>
 
   <export>
     <architecture_independent />


### PR DESCRIPTION
Package dependencies were in the wrong format. The have been fixed, so rosdep can now correctly install them.
Instruction for installing dependencies using rosdep were added to the README.
Sonar rangefinders are now displayed by default in rviz.