### PR TITLE
Fix center of empty map

### DIFF
--- a/mse6_config/config/localization/maps/empty/move_base_map.yaml
+++ b/mse6_config/config/localization/maps/empty/move_base_map.yaml
@@ -1,6 +1,6 @@
 image: move_base_map.bmp
 resolution: 0.1
-origin: [-15.0, -15.0, 0]
+origin: [-20.0, -20.0, 0]
 occupied_thresh: 0.5
 free_thresh: 0.3
 negate: 0


### PR DESCRIPTION
Map parameters of "empty" were not centered (40x40 map, center was in 15,15). Fixed that.